### PR TITLE
commented out _fd questions in BufferAllocator.h

### DIFF
--- a/mtp/backend/linux/usb/BufferAllocator.h
+++ b/mtp/backend/linux/usb/BufferAllocator.h
@@ -77,7 +77,7 @@ namespace mtp { namespace usb
 
 		~BufferAllocator()
 		{
-			if (_fd >= 0)
+			// if (_fd >= 0)
 				munmap(_buffer, _bufferSize);
 		}
 
@@ -94,7 +94,7 @@ namespace mtp { namespace usb
 			if (!_buffer)
 			{
 				_bufferSize = (BufferSize + _pageSize - 1) / _pageSize * _pageSize;
-				if (_fd >= 0)
+				/* if (_fd >= 0)
 				{
 					try
 					{
@@ -111,7 +111,7 @@ namespace mtp { namespace usb
 						AllocateNormalBuffer();
 					}
 				}
-				else
+				else */
 					AllocateNormalBuffer();
 			}
 			if (size > BufferSize)


### PR DESCRIPTION
i just commented out the `_fd` questions... i tested this and it works on my ARMv7 laptop

this is a crude edit, just to mimic the behavior of the last version of this program that worked for me:
"use shared mappings for usb buffers "c0cfe280e46e3f9d4b6e95e88616d0669ed04668"

when the following commit was introduced, this program didn't work on my laptop anymore:
"enabled zerocopy allocator if it's available 1ddff3e5e75800772d1fd84611c443d750fd7168"